### PR TITLE
don't filter out empty lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 0.8
+  - 1.2

--- a/index.js
+++ b/index.js
@@ -189,9 +189,7 @@ Gedcom.prototype._setStreamUnwritable = function () {
 };
 
 Gedcom.prototype._splitBufferByNewlines = function () {
-  return this._buffer.split(/\r?\n/).filter(function (line) {
-    return line !== '';
-  });
+  return this._buffer.split(/\r?\n/);
 };
 
 module.exports = Gedcom;

--- a/test/index.js
+++ b/test/index.js
@@ -7,8 +7,32 @@ describe('Core', function () {
   var gedcomStream,
       data;
 
+  var expected = {
+    'nested': [
+      { id: 'I1', name: 'INDI', value: '', children: [
+        { name: 'NAME', value: 'Joe Bloggs', children: [] }
+      ] },
+      { id: 'I2', name: 'INDI', value: '', children: [
+        { name: 'NAME', value: 'Jim Bliggs', children: [] },
+        { name: 'ASSO', value: '@I1@', children: [
+          { name: 'RELA', value: 'Godfather', children: [] }
+        ] }
+      ] }
+    ],
+    'single': [
+      { id: 'I1', name: 'INDI', value: '', children: [
+        { name: 'NAME', value: '', children: [] }
+      ]},
+      { id: 'I2', name: 'INDI', value: '', children: [
+      ]}
+    ],
+  };
+
   beforeEach(function () {
     gedcomStream = new GedcomStream();
+    // for some reason the event listeners persist even after recreating the object
+    // which makes the 2nd test case fire the first test comparison
+    gedcomStream.removeAllListeners('end');
     data = [];
     gedcomStream.on('data', data.push.bind(data));
   });
@@ -19,13 +43,7 @@ describe('Core', function () {
 
   it('returns an array with a nested object', function (done) {
     gedcomStream.on('end', function () {
-      assert.deepEqual(data, [
-        { id: 'I1', name: 'INDI', value: '', children: [
-          { name: 'NAME', value: '', children: [] }
-        ]},
-        { id: 'I2', name: 'INDI', value: '', children: [
-        ]}
-      ]);
+      assert.deepEqual(expected['single'], data);
       done();
     });
     createStream('single_object.ged').pipe(gedcomStream);
@@ -33,25 +51,31 @@ describe('Core', function () {
 
   it('returns a multilevel array for multilevel GEDCOM files', function (done) {
     gedcomStream.on('end', function () {
-      assert.deepEqual(data, [
-        { id: 'I1', name: 'INDI', value: '', children: [
-          { name: 'NAME', value: 'Joe Bloggs', children: [] }
-        ] },
-        { id: 'I2', name: 'INDI', value: '', children: [
-          { name: 'NAME', value: 'Jim Bliggs', children: [] },
-          { name: 'ASSO', value: '@I1@', children: [
-            { name: 'RELA', value: 'Godfather', children: [] }
-          ] }
-        ] }
-      ]);
+      assert.deepEqual(expected['nested'], data);
       done();
     });
     createStream('nested_objects.ged').pipe(gedcomStream);
   });
 
+  it('parses correctly when a chunk ends on newline', function (done) {
+    gedcomStream.on('end', function () {
+      assert.deepEqual(expected['nested'], data);
+      done();
+    });
+    var input = createStream('nested_objects.ged');
+    input.on('readable', function() {
+      // we can't set the chunk size on a piped stream, so we have to manually process
+      var chunk;
+      while (null !== (chunk = input.read(42))) {
+        gedcomStream.write(chunk);
+      }
+    });
+    input.on('end', gedcomStream.end.bind(gedcomStream));
+  })
+
   it('throws an error when the GEDCOM entry nesting is malformed', function (done) {
     gedcomStream.on('error', function (err) {
-      assert.throws(err, Error);
+      assert.ok(err instanceof Error);
       done();
     });
     createStream('malformed_gedcom.ged').pipe(gedcomStream);


### PR DESCRIPTION
If the chunk of data ended with a newline, filtering
out the "empty" line causes the next line to be appended
to the end of the last line, so you get something like:

@I12345@ INDI1 NAME Jim /Bob/

This creates an INDI1 tag with a value of 'NAME Jim /Bob/'
instead of an INDI tag with a child node of NAME = 'Jim /Bob/'
